### PR TITLE
Added skill bonuses and ability score bonuses 

### DIFF
--- a/campaign/record_char_main.xml
+++ b/campaign/record_char_main.xml
@@ -33,7 +33,7 @@
 						return CharManagerWith4ERaceExtension.onRaceLinkPressed(window.getDatabaseNode());
 					end
 				</script>
-			</linkfield_statich>
+			</linkfield_statich>	
 		</sheetdata>
 	</windowclass>
 </root>

--- a/campaign/record_char_skill_with_racebonus.xml
+++ b/campaign/record_char_skill_with_racebonus.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+
+<!-- 
+  Please see the license.html file included with this distribution for 
+  attribution and copyright information.
+-->
+
+<root>
+	<windowclass name="char_skill" merge="join">
+		<sheetdata>
+			<number_charskilltotal name="total">
+				<source>
+					<name>race</name>
+					<op>+</op>
+				</source>
+			</number_charskilltotal>
+		</sheetdata>
+	</windowclass>
+</root>

--- a/strings/strings_4E_char_build.xml
+++ b/strings/strings_4E_char_build.xml
@@ -11,8 +11,14 @@
   <string name="char_abilities_message_featureadd">Racial Trait '%s' added to '%s' special ability list.</string>
   <string name="char_abilities_message_poweradd">Racial Power '%s' added to '%s' powers list.</string>
   <string name="char_combat_message_speedadd">Base Speed set to '%s' for '%s'.</string>  
-  <string name="char_combat_message_specialspeedadd">Special Movement set to '%s' for '%s'.</string>
-  <string name="char_combat_message_sizeadd">Size set to '%s' for '%s'.</string>
-  <string name="char_combat_message_visionadd">Senses set to '%s' for '%s'.</string>
-  <string name="char_combat_message_languageadd">Language '%s' added to '%s' language list.</string>
+  <string name="char_main_message_specialspeedadd">Special Movement set to '%s' for '%s'.</string>
+  <string name="char_notes_message_sizeadd">Size set to '%s' for '%s'.</string>
+  <string name="char_main_message_visionadd">Senses set to '%s' for '%s'.</string>
+  <string name="char_notes_message_languageadd">Language '%s' added to '%s' language list.</string>
+  <string name="char_skills_message_skillbonusadd">+%s bonus given to '%s' skill for '%s'.</string>
+  <string name="char_main_message_statbonusadd">+%s %s bonus for '%s'.</string>
+
+  <string name="char_build_title_selectraceabilitybonus">Increase Ability Score</string>
+  <string name="char_build_message_selectraceabilitybonus">Select an ability score increase.</string>
+  <string name="char_error_addrace">Error adding race ability score.</string>
 </root>


### PR DESCRIPTION
Added skill bonuses and ability score bonuses when dragging a race to a character's main sheet
Skill bonuses are automatically replaced when adding a different race to a character (unlike everything else at the moment, except for speed, special movement, senses, and size).
Ability score bonuses are automatically added. If you have a choice between a few, then a dialogue will appear where you can select your choice.