### PR TITLE
Can now drag a race record onto a character's skill sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ v.0.2.0 - 06/05/2025 - Added new tabs to the race library records. The second on
 v.0.3.0 - 06/09/2025 - Added speed to character when race is drag-and-dropped on character main sheet.  
 v.0.4.0 - 06/09/2025 - Added special movement, senses/vision, and languages to race information that is added when a race is drag-and-dropped on a character main sheet.  
 v.0.5.0 - 06/11/2025 - Added skills and ability score bonuses to race information that is added when a race is drag-and-dropped on a character sheet. Skills are replaced when another race is added, ability score bonuses are not. If the race gives a choice between multiple ability scores, a dialogue box appears where you can select the one you want.  
-v.0.6.0 - 06/17/2025 - Race bonuses should be able to parse better from description text, making it work better with older versions of the compendium module. Powers, features, etc are also no longer added when they already exist on the character. Racial ability score bonuses are reset when adding a new race.
+v.0.6.0 - 06/17/2025 - Race bonuses should be able to parse better from description text, making it work better with older versions of the compendium module. Powers, features, etc are also no longer added when they already exist on the character. Racial ability score bonuses are reset when adding a new race.   
+v0.6.1 - 10/06/2025 - Fixed racial skill bonuses not getting added to characters.   
+v0.6.2 - 11/02/2025 - Fixed a bug preventing this extension from working with my DnD 4e Classes Extension.   
+v0.6.3 - 11/10/2025 - Can now drag races onto the character's skill sheet, in addition to the main sheet.
 
-v0.6.1 - 10/06/2025 - Fixed racial skill bonuses not getting added to characters.
-
-v0.6.2 - 11/02/2025 - Fixed a bug preventing this extension from working with my DnD 4e Classes Extension.
 

--- a/campaign/record_char_skills.xml
+++ b/campaign/record_char_skills.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+
+<!-- 
+  Please see the license.html file included with this distribution for 
+  attribution and copyright information.
+-->
+
+<root>
+  <windowclass name="charsheet_skills" merge="join">
+    <script>
+      function onDrop(x, y, draginfo)
+        if super and super.onDrop then
+          super.onDrop(x, y, draginfo);
+        end
+
+        if draginfo.isType("shortcut") then
+          local sClass, sRecord = draginfo.getShortcutData();
+          if StringManager.startsWith(sRecord, "reference.races") or StringManager.startsWith(sRecord, "race.id-") then
+            return CharRaceBuildDropManager.addInfoDB(getDatabaseNode(), sClass, sRecord);
+          end
+        end
+      end
+    </script>
+  </windowclass>
+</root>

--- a/extension.xml
+++ b/extension.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- This is our MVP for the Practice Extension -->
 <root release="3.0" version="6">
-	<announcement text="DnD 4e Races extension made by SieferSeesSomething is activated. Last release 11/2/2025" font="emotefont" icon="rulesetlogo_CoreRPG"/>
+	<announcement text="DnD 4e Races extension made by SieferSeesSomething is activated. Last release 11/10/2025" font="emotefont" icon="rulesetlogo_CoreRPG"/>
 	<properties>
 		<name>DnD 4e - Character Races Extension</name>
-		<version>0.6.2</version>
+		<version>0.6.3</version>
 		<author>Jason Williams</author>
 		<description>
 		Adds a character options menu for races and a link to the character sheet.
@@ -22,6 +22,7 @@
 		<includefile source="campaign/record_char_main.xml" />
 		<includefile source="campaign/record_race.xml" />
 		<includefile source="campaign/record_char_skill_with_racebonus.xml" />
+		<includefile source="campaign/record_char_skills.xml" /> 
 
 		<!-- High-Level Scripts -->
 		<script name="CharManagerWith4ERaceExtension" file="scripts/manager_char_4e.lua" />		


### PR DESCRIPTION
Can now drag a race record onto a character's skill sheet, in addition to the main tab, in order to update their race. (This should help push skill changes if they didn't happen the first time you added them to a character.)